### PR TITLE
「ignore: avoid_classes_with_only_static_members」の削除

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -1,20 +1,23 @@
 # https://qiita.com/gki/items/a861d7ac1c61d6de928e
 # https://github.com/priezz/dart_full_coverage
-#!/bin/sh
+#/bin/sh
 
 outputFile="$(pwd)/test/coverage_test.dart"
-packageName="$(cat pubspec.yaml| grep '^name: ' | awk '{print $2}')"
+packageName="$(< pubspec.yaml grep '^name: ' | awk '{print $2}')"
 
 if [ "$packageName" = "" ]; then
     echo "Run $0 from the root of your Dart/Flutter project"
     exit 1
 fi
 
-echo "/// *** GENERATED FILE - ANY CHANGES WOULD BE OBSOLETE ON NEXT GENERATION *** ///\n" > "$outputFile"
-echo "/// Helper to test coverage for all project files" >> "$outputFile"
-echo "// ignore_for_file: unused_import" >> "$outputFile"
-find lib -name '*.dart' | grep -v '.g.dart' | grep -v '.freezed.dart' | grep -v 'generated_plugin_registrant' | awk -v package=$packageName '{gsub("^lib", "", $1); printf("import '\''package:%s%s'\'';\n", package, $1);}' >> "$outputFile"
-echo "\nvoid main() {}" >> "$outputFile"
+printf "/// *** GENERATED FILE - ANY CHANGES WOULD BE OBSOLETE ON NEXT GENERATION *** ///\n" > "$outputFile"
+
+{
+  printf "/// Helper to test coverage for all project files\n"
+  printf "// ignore_for_file: unused_import\n"
+  find lib -name '*.dart' | grep -v '.g.dart' | grep -v '.freezed.dart' | grep -v 'generated_plugin_registrant' | awk -v package="$packageName" '{gsub("^lib", "", $1); printf("import '\''package:%s%s'\'';\n", package, $1);}'
+  printf "\nvoid main() {}"
+} >> "$outputFile"
 
 flutter test --coverage
 
@@ -22,7 +25,7 @@ lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/l
 
 genhtml coverage/lcov.info -o coverage/result
 
-rm $outputFile
+rm "$outputFile"
 
 # open coverage html
 # open coverage/result/index.html

--- a/lib/constant/app_platform.dart
+++ b/lib/constant/app_platform.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 
-// ignore: avoid_classes_with_only_static_members
 /// アプリのPlatform判定を行います。(テスト可能にした)
 class AppPlatform {
+  /// private constructor
+  AppPlatform._();
+
   /// 動作中のPlatformを上書きします。
   @visibleForTesting
   static Platforms? overridePlatForm;

--- a/lib/constant/app_platform.dart
+++ b/lib/constant/app_platform.dart
@@ -5,7 +5,7 @@ import 'package:flutter/cupertino.dart';
 /// アプリのPlatform判定を行います。(テスト可能にした)
 class AppPlatform {
   /// private constructor
-  AppPlatform._();
+  AppPlatform._(); // coverage:ignore-line
 
   /// 動作中のPlatformを上書きします。
   @visibleForTesting


### PR DESCRIPTION
- ignore: avoid_classes_with_only_static_membersをプライベートコンストラクタを定義して削除
- coverage.shのリファクタリング