### PR TITLE
Edge-To-Edgeで埋まっていた画面を修正

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "com.mry.wordquiz"
     compileSdkVersion = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "25.1.8937393"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_18

--- a/lib/ui/how_to_play/how_to_play_page.dart
+++ b/lib/ui/how_to_play/how_to_play_page.dart
@@ -85,6 +85,7 @@ class HowToPlayPage extends ConsumerWidget {
               const RuleSameWordContent(),
               const Divider(),
               const ForDevelopersInfo(),
+              SizedBox(height: MediaQuery.of(context).padding.bottom),
             ],
           ),
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -422,10 +422,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   intl:
     dependency: "direct main"
     description:
@@ -979,10 +979,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
+      sha256: "154360849a56b7b67331c21f09a386562d88903f90a1099c5987afc1912e1f29"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.0"
+    version: "5.10.0"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
<img src=https://github.com/user-attachments/assets/bde336dd-f3ba-42d9-a726-832f889f5e56 height=600 /> <img src=https://github.com/user-attachments/assets/351c9fea-0e9f-4958-b26f-7be522c54758 height=600 />

Androidビルド警告ログも修正 [7d9d8da](https://github.com/YoshihideSogawa/flutter_word_quiz/pull/17/commits/7d9d8da38800ac6ff4189b82fe5c47c3975d4e5c)
