### PR TITLE
DynamicLinksのリンクをタップするとNot Foundページが表示される不具合修正

### DIFF
--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -8,28 +8,29 @@ import 'package:word_quiz/ui/splash/splash_page.dart';
 
 /// [GoRouter]を取得します。
 final router = GoRouter(
-      initialLocation: Routes.root,
-      debugLogDiagnostics: true,
-      routes: [
-        GoRoute(
-          path: Routes.root,
-          builder: (_, __) => const SplashPage(),
-        ),
-        GoRoute(
-          path: Routes.quiz,
-          builder: (_, __) => const QuizPage(),
-        ),
-        GoRoute(
-          path: Routes.parentalGate,
-          builder: (_, __) => const ParentalGatePage(),
-        ),
-        GoRoute(
-          path: Routes.settings,
-          builder: (_, __) => const SettingsPage(),
-        ),
-        GoRoute(
-          path: Routes.howToPlay,
-          builder: (_, __) => const HowToPlayPage(),
-        ),
-      ],
-    );
+  initialLocation: Routes.root,
+  debugLogDiagnostics: true,
+  onException: (_, __, router) => router.go(Routes.root),
+  routes: [
+    GoRoute(
+      path: Routes.root,
+      builder: (_, __) => const SplashPage(),
+    ),
+    GoRoute(
+      path: Routes.quiz,
+      builder: (_, __) => const QuizPage(),
+    ),
+    GoRoute(
+      path: Routes.parentalGate,
+      builder: (_, __) => const ParentalGatePage(),
+    ),
+    GoRoute(
+      path: Routes.settings,
+      builder: (_, __) => const SettingsPage(),
+    ),
+    GoRoute(
+      path: Routes.howToPlay,
+      builder: (_, __) => const HowToPlayPage(),
+    ),
+  ],
+);


### PR DESCRIPTION
## 内容
アプリがインストール済みの場合、XのリンクをタップするとNot Foundページが表示されていた

## 解決策
onExceptionでトップにリダイレクトするように修正