### PR TITLE
起動時に閉じるボタンの反応が遅い不具合修正

### DIFF
--- a/lib/ui/quiz/component/statistics_view.dart
+++ b/lib/ui/quiz/component/statistics_view.dart
@@ -148,10 +148,10 @@ class StatisticsView extends ConsumerWidget {
 
   /// この画面を閉じます。(問題の更新があれば更新します。)
   Future<void> close(WidgetRef ref, QuizTypes quizType) async {
+    quizPageInfo.value = quizPageInfo.value.copyWith(showStatistics: false);
     await ref
         .read(quizInfoNotifierProvider(quizType).notifier)
         .refreshDailyQuiz();
-    quizPageInfo.value = quizPageInfo.value.copyWith(showStatistics: false);
   }
 }
 


### PR DESCRIPTION
## 手順
1. アプリを起動する
2. きょうのもんだい の画面が表示される
3. 閉じるを押す
4. 少ししてから画面が閉じる

## 対策
- 画面を先に閉じるように修正（連打防止）